### PR TITLE
WIP: (feature) add anisotropic meshing to LearnerND

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -12,8 +12,9 @@ from .base_learner import BaseLearner
 
 from ..notebook_integration import ensure_holoviews
 from .triangulation import (Triangulation, point_in_simplex,
-                            circumsphere, simplex_volume_in_embedding)
+                            circumsphere, simplex_volume_in_embedding, FakeDelaunay)
 from ..utils import restore
+import math
 
 
 def volume(simplex, ys=None):
@@ -217,8 +218,9 @@ class LearnerND(BaseLearner):
         return all(p in self.data for p in self._bounds_points)
 
     def ip(self):
-        # XXX: take our own triangulation into account when generating the ip
-        return interpolate.LinearNDInterpolator(self.points, self.values)
+        fd = FakeDelaunay(self.tri.vertices, self.tri.simplices)
+        values = list(map(lambda k: self.data[k], self.tri.vertices))
+        return interpolate.LinearNDInterpolator(fd, values) 
 
     @property
     def tri(self):

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -315,8 +315,8 @@ class LearnerND(BaseLearner):
         simplex = tuple(sorted(simplex))
         return simplex in self.tri.simplices
 
-    def inside_bounds(self, point):
-        return all(mn <= p <= mx for p, (mn, mx) in zip(point, self.bounds))
+    def inside_bounds(self, point, eps = 1e-8):
+        return all((mn - eps) <= p <= (mx + eps) for p, (mn, mx) in zip(point, self.bounds))
             
     def tell_pending(self, point, *, simplex=None):
         point = tuple(point)

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -312,7 +312,7 @@ class LearnerND(BaseLearner):
         identity = np.eye(self.ndim)
 
         factor = math.sqrt(magnitude ** 2 + 1) - 1
-        factor = min(factor, 2)
+        # factor = min(factor, 2)
 
         scale_along_gradient = projection_matrix * factor * 1 + identity
         m = np.dot(scale_along_gradient, scale)

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -218,9 +218,9 @@ class LearnerND(BaseLearner):
         return all(p in self.data for p in self._bounds_points)
 
     def ip(self):
-        fd = FakeDelaunay(self.tri.vertices, self.tri.simplices)
-        values = list(map(lambda k: self.data[k], self.tri.vertices))
-        return interpolate.LinearNDInterpolator(fd, values) 
+        tri = FakeDelaunay(self.tri.vertices, self.tri.simplices)
+        values = [self.data[k] for k in self.tri.vertices]
+        return interpolate.LinearNDInterpolator(tri, values)
 
     @property
     def tri(self):
@@ -290,7 +290,7 @@ class LearnerND(BaseLearner):
         ones = np.ones((len(points), 1))
         A = np.hstack((points, ones))
         B = np.array(values, dtype=float)
-        fit, *_ = np.linalg.lstsq(A, B, rcond=None)
+        fit = np.linalg.lstsq(A, B, rcond=None)[0]
         *gradient, _constant = fit
         # we do not need the constant, only the gradient
 

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -309,6 +309,8 @@ class LearnerND(BaseLearner):
         r = np.array([self._random.random() for _ in range(self.ndim)])
         p = r * a + b
         p = tuple(p)
+
+        self._tell_pending(p)
         return p, np.inf
 
     def _pop_highest_existing_simplex(self):
@@ -360,7 +362,7 @@ class LearnerND(BaseLearner):
             # we have no known simplices
             return self._ask_point_without_known_simplices()  # O(1)
 
-        return self._ask_best_point()  # O(??)
+        return self._ask_best_point()  # O(log N)
 
     def update_losses(self, to_delete: set, to_add: set):
         pending_points_unbound = set()  # XXX: add the points outside the triangulation to this as well

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -282,29 +282,31 @@ class LearnerND(BaseLearner):
         self._tell_pending(new_point)
         return new_point, np.inf
 
+    def _ask_point_without_known_simplices(self):
+        # pick a random point inside the bounds
+        # XXX: change this into picking a point based on volume loss
+        a = np.diff(self.bounds).flat
+        b = np.array(self.bounds)[:, 0]
+        r = np.array([self._random.random() for _ in range(self.ndim)])
+        p = r * a + b
+        p = tuple(p)
+        return p, np.inf
+
     def _ask(self):
         # Complexity: O(N log N)
-        # XXX: adapt this function
-        # XXX: allow cases where n > 1
-
         if not self.bounds_are_done:
             return self._ask_bound_point()
 
-        losses = [(-v, k) for k, v in self.losses().items()]
-        heapq.heapify(losses)
+        losses = [(-v, k) for k, v in self.losses().items()]  # O(N)
+        heapq.heapify(losses)  # O(N log N)
         pending_losses = []  # also a heap
 
         new_points = []
         new_loss_improvements = []
 
         if len(losses) == 0:
-            # pick a random point inside the bounds
-            a = np.diff(self.bounds).flat
-            b = np.array(self.bounds)[:, 0]
-            r = np.array([self._random.random() for _ in range(self.ndim)])
-            p = r * a + b
-            p = tuple(p)
-            return p, np.inf
+            # we have no known simplices
+            return self._ask_point_without_known_simplices()
 
         while len(new_points) < 1:
             if len(losses):

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -60,9 +60,9 @@ def std_loss(simplex, ys):
 def default_loss(simplex, ys):
     # return std_loss(simplex, ys)
     if isinstance(ys[0], Iterable):
-        pts = [(*s, *ys[i]) for i, s in enumerate(simplex)]
+        pts = [(*x, *y) for x, y in zip(simplex, ys)]
     else:
-        pts = [(*s, ys[i]) for i, s in enumerate(simplex)]
+        pts = [(*x, y) for x, y in zip(simplex, ys)]
     return simplex_volume_in_embedding(pts)
 
 

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -58,16 +58,25 @@ def std_loss(simplex, ys):
 
 
 def simplex_volume(vertices) -> float:
-    """
-    Return the volume of the simplex with given vertices.
+    """Calculate the volume of a simplex in a higher dimensional embedding.
+    That is: dim > len(vertices) - 1. For example if you would like to know the 
+    surface area of a triangle in a 3d space.
 
-    If vertices are given they must be in a arraylike with shape (N+1, N):
-    the position vectors of the N+1 vertices in N dimensions. If the sides
-    are given, they must be the compressed pairwise distance matrix as
-    returned from scipy.spatial.distance.pdist.
+    Parameters
+    ----------
+    vertices: arraylike (2 dimensional)
+        array of points
 
-    Raises a ValueError if the vertices do not form a simplex (for example,
-    because they are coplanar, colinear or coincident).
+    Returns
+    -------
+    volume: int
+        the volume of the simplex with given vertices.
+
+    Raises
+    ------
+    ValueError:
+        if the vertices do not form a simplex (for example,
+        because they are coplanar, colinear or coincident).
 
     Warning: this algorithm has not been tested for numerical stability.
     """
@@ -107,7 +116,9 @@ def default_loss(simplex, ys):
 def choose_point_in_simplex(simplex, transform=None):
     """Choose a new point in inside a simplex.
 
-    Pick the center of the longest edge of this simplex
+    Pick the center of the simplex if the shape is nice (that is, the 
+    circumcenter lies within the simplex). Otherwise take the middle of the 
+    longest edge.
 
     Parameters
     ----------
@@ -118,7 +129,7 @@ def choose_point_in_simplex(simplex, transform=None):
 
     Returns
     -------
-    point : numpy array
+    point : numpy array of length N
         The coordinates of the suggested new point.
     """
 
@@ -126,20 +137,23 @@ def choose_point_in_simplex(simplex, transform=None):
     if transform is not None:
         simplex = np.dot(simplex, transform)
 
-    # choose center iff the shape of the simplex is nice,
-    # otherwise the longest edge
+    # choose center if and only if the shape of the simplex is nice,
+    # otherwise: the longest edge
     center, _radius = circumsphere(simplex)
     if point_in_simplex(center, simplex):
         point = np.average(simplex, axis=0)
     else:
         distances = scipy.spatial.distance.pdist(simplex)
         distance_matrix = scipy.spatial.distance.squareform(distances)
-        i, j = np.unravel_index(np.argmax(distance_matrix), 
+        i, j = np.unravel_index(np.argmax(distance_matrix),
                                 distance_matrix.shape)
 
         point = (simplex[i, :] + simplex[j, :]) / 2
 
-    return np.linalg.solve(transform, point)  # undo the transform
+    if transform is not None:
+        point = np.linalg.solve(transform, point)  # undo the transform
+        
+    return point
 
 
 class LearnerND(BaseLearner):

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -40,7 +40,7 @@ def volume(simplex, ys=None):
 def orientation(simplex):
     matrix = np.subtract(simplex[:-1], simplex[-1])
     # See https://www.jstor.org/stable/2315353
-    sign, logdet = np.linalg.slogdet(matrix)
+    sign, _logdet = np.linalg.slogdet(matrix)
     return sign
 
 
@@ -128,13 +128,14 @@ def choose_point_in_simplex(simplex, transform=None):
 
     # choose center iff the shape of the simplex is nice,
     # otherwise the longest edge
-    center, radius = circumsphere(simplex)
+    center, _radius = circumsphere(simplex)
     if point_in_simplex(center, simplex):
         point = np.average(simplex, axis=0)
     else:
         distances = scipy.spatial.distance.pdist(simplex)
         distance_matrix = scipy.spatial.distance.squareform(distances)
-        i, j = np.unravel_index(np.argmax(distance_matrix), distance_matrix.shape)
+        i, j = np.unravel_index(np.argmax(distance_matrix), 
+                                distance_matrix.shape)
 
         point = (simplex[i, :] + simplex[j, :]) / 2
 
@@ -364,14 +365,16 @@ class LearnerND(BaseLearner):
             if len(losses):
                 loss, simplex = heapq.heappop(losses)
 
-                assert self._simplex_exists(simplex), "all simplices in the heap should exist"
+                assert self._simplex_exists(simplex), \
+                    "all simplices in the heap should exist"
 
                 if simplex in self._subtriangulations:
                     subtri = self._subtriangulations[simplex]
                     loss_density = loss / self.tri.volume(simplex)
                     for pend_simplex in subtri.simplices:
                         pend_loss = subtri.volume(pend_simplex) * loss_density
-                        heapq.heappush(pending_losses, (pend_loss, simplex, pend_simplex))
+                        heapq.heappush(
+                            pending_losses, (pend_loss, simplex, pend_simplex))
                     continue
             else:
                 loss = 0
@@ -401,7 +404,8 @@ class LearnerND(BaseLearner):
         return new_points[0], new_loss_improvements[0]
 
     def update_losses(self, to_delete: set, to_add: set):
-        pending_points_unbound = set()  # XXX: add the points outside the triangulation to this as well
+        # XXX: add the points outside the triangulation to this as well
+        pending_points_unbound = set()
 
         for simplex in to_delete:
             self._losses.pop(simplex, None)
@@ -466,8 +470,8 @@ class LearnerND(BaseLearner):
             raise NotImplementedError('holoviews currently does not support',
                                       '3D surface plots in bokeh.')
         if len(self.bounds) != 2:
-           raise NotImplementedError("Only 2D plots are implemented: You can "
-                                     "plot a 2D slice with 'plot_slice'.")
+            raise NotImplementedError("Only 2D plots are implemented: You can "
+                                      "plot a 2D slice with 'plot_slice'.")
         x, y = self.bounds
         lbrt = x[0], y[0], x[1], y[1]
 

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from collections import OrderedDict
+from collections import OrderedDict, Iterable
 import itertools
 import heapq
 
@@ -12,6 +12,7 @@ from .base_learner import BaseLearner
 
 from .triangulation import Triangulation
 import random
+from math import factorial
 
 
 def find_initial_simplex(pts, ndim):
@@ -56,8 +57,51 @@ def std_loss(simplex, ys):
     return r.flat * np.power(vol, 1. / dim) + vol
 
 
+def simplex_volume(vertices) -> float:
+    """
+    Return the volume of the simplex with given vertices.
+
+    If vertices are given they must be in a arraylike with shape (N+1, N):
+    the position vectors of the N+1 vertices in N dimensions. If the sides
+    are given, they must be the compressed pairwise distance matrix as
+    returned from scipy.spatial.distance.pdist.
+
+    Raises a ValueError if the vertices do not form a simplex (for example,
+    because they are coplanar, colinear or coincident).
+
+    Warning: this algorithm has not been tested for numerical stability.
+    """
+
+    # Implements http://mathworld.wolfram.com/Cayley-MengerDeterminant.html
+    # Modified from https://codereview.stackexchange.com/questions/77593/calculating-the-volume-of-a-tetrahedron
+
+    # β_ij = |v_i - v_k|²
+    vertices = np.array(vertices, dtype=float)
+    sq_dists = scipy.spatial.distance.pdist(vertices, metric='sqeuclidean')
+
+    # Add border while compressed
+    num_verts = scipy.spatial.distance.num_obs_y(sq_dists)
+    bordered = np.concatenate((np.ones(num_verts), sq_dists))
+
+    # Make matrix and find volume
+    sq_dists_mat = scipy.spatial.distance.squareform(bordered)
+
+    coeff = - (-2) ** (num_verts-1) * factorial(num_verts-1) ** 2
+    vol_square = np.linalg.det(sq_dists_mat) / coeff
+
+    if vol_square <= 0:
+        raise ValueError('Provided vertices do not form a tetrahedron')
+
+    return np.sqrt(vol_square)
+
+
 def default_loss(simplex, ys):
-    return std_loss(simplex, ys)
+    # return std_loss(simplex, ys)
+    if isinstance(ys[0], Iterable):
+        pts = [(*s, *ys[i]) for i, s in enumerate(simplex)]
+    else:
+        pts = [(*s, ys[i]) for i, s in enumerate(simplex)]
+    return simplex_volume(pts)
 
 
 def choose_point_in_simplex(simplex, transform=None):

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -11,7 +11,7 @@ from .base_learner import BaseLearner
 
 from .triangulation import Triangulation
 import random
-from sortedcontainers import SortedList
+import heapq
 
 
 def find_initial_simplex(pts, ndim):
@@ -172,14 +172,9 @@ class LearnerND(BaseLearner):
         # create a private random number generator with fixed seed
         self._random = random.Random(1)
 
-        # All real triangles
-        # list of tuple (loss, simplex)
-        self._losses_list = SortedList()
-
-        # all real triangles that have not been subdivided and the pending triangles
-        # list of tuple (loss, real simplex, sub_simplex or None)
-        self._losses_combined_list = SortedList()
-        self._sub_losses = dict()  # map the other way around
+        # all real triangles that have not been subdivided and the pending 
+        # triangles heap of tuples (-loss, real simplex, sub_simplex or None)
+        self._losses_combined = [] # heap
 
     @property
     def npoints(self):
@@ -202,11 +197,6 @@ class LearnerND(BaseLearner):
     def ip(self):
         # XXX: take our own triangulation into account when generating the ip
         return interpolate.LinearNDInterpolator(self.points, self.values)
-
-    def _get_loss(self, simplex, subsimplex=None):
-        if subsimplex is None:
-            return self._losses[simplex]
-        return self._sub_losses[(simplex, subsimplex)]
 
     @property
     def tri(self):
@@ -285,26 +275,19 @@ class LearnerND(BaseLearner):
             if simpl not in self._subtriangulations:
                 vertices = self.tri.get_vertices(simpl)
                 tr = self._subtriangulations[simpl] = Triangulation(vertices)
-                todel, toadd = tr.add_point(point, next(iter(tr.simplices)))
+                _, toadd = tr.add_point(point, next(iter(tr.simplices)))
             else:
-                todel, toadd = self._subtriangulations[simpl].add_point(point)
-
-            for subsimplex in todel:
-                if subsimplex == tuple(range(self.ndim + 1)):
-                    continue
-                subloss = self._sub_losses.pop((simpl, subsimplex))
-                self._losses_combined_list.discard((subloss, simpl, subsimplex))
+                _, toadd = self._subtriangulations[simpl].add_point(point)
 
             loss = self._losses[simpl]
-            self._losses_combined_list.discard((loss, simpl, None))
 
-            loss = self._losses[simpl]
             loss_density = loss / self.tri.volume(simpl)
             subtriangulation = self._subtriangulations[simpl]
             for subsimplex in toadd:
                 subloss = subtriangulation.volume(subsimplex) * loss_density
-                self._losses_combined_list.add((subloss, simpl, subsimplex))
-                self._sub_losses[(simpl, subsimplex)] = subloss
+                heapq.heappush(self._losses_combined, 
+                               (-subloss, simpl, subsimplex))
+                
 
     def ask(self, n=1):
         xs, losses = zip(*(self._ask() for _ in range(n)))
@@ -328,12 +311,26 @@ class LearnerND(BaseLearner):
         p = tuple(p)
         return p, np.inf
 
+    def _pop_highest_existing_simplex(self):
+        # find the simplex with the highest loss, we do need to check that the
+        # simplex hasn't been deleted yet
+        while True:
+            loss, simplex, subsimplex = heapq.heappop(self._losses_combined) 
+            if (subsimplex is None and 
+                    simplex in self.tri.simplices and 
+                    simplex not in self._subtriangulations):
+                return abs(loss), simplex, subsimplex
+            if (simplex in self._subtriangulations and
+                    simplex in self.tri.simplices and 
+                    subsimplex in self._subtriangulations[simplex].simplices):
+                return abs(loss), simplex, subsimplex
+
+
     def _ask_best_point(self):
         assert not self._bounds_available
         assert self.tri is not None
 
-        # _losses_combined is a SortedList. pop() will give us the highest loss
-        loss, simplex, subsimplex = self._losses_combined_list.pop()  # O(log N)
+        loss, simplex, subsimplex = self._pop_highest_existing_simplex()
 
         if subsimplex is None:
             # We found a real simplex and want to subdivide it
@@ -370,16 +367,9 @@ class LearnerND(BaseLearner):
 
         for simplex in to_delete:
             loss = self._losses.pop(simplex, None)
-            self._losses_list.discard((loss, simplex))
-            self._losses_combined_list.discard((loss, simplex, None))
             subtri = self._subtriangulations.pop(simplex, None)
-            if subtri is None:
-                continue
-
-            pending_points_unbound.update(subtri.vertices)
-            for subsimplex in subtri.simplices:
-                subloss = self._sub_losses[(simplex, subsimplex)]
-                self._losses_combined_list.discard((subloss, simplex, subsimplex))
+            if subtri is not None:
+                pending_points_unbound.update(subtri.vertices)
 
         pending_points_unbound = set(p for p in pending_points_unbound
                                      if p not in self.data)
@@ -389,7 +379,6 @@ class LearnerND(BaseLearner):
             values = [self.data[tuple(v)] for v in vertices]
             loss = float(self.loss_per_simplex(vertices, values))
             self._losses[simplex] = float(loss)
-            self._losses_list.add((loss, simplex))
 
             for p in pending_points_unbound:
                 # try to insert it
@@ -404,15 +393,15 @@ class LearnerND(BaseLearner):
                 self._pending_to_simplex[p] = simplex
 
             if simplex not in self._subtriangulations:
-                self._losses_combined_list.add((loss, simplex, None))
+                heapq.heappush(self._losses_combined, (-loss, simplex, None))
                 continue
 
             loss_density = loss / self.tri.volume(simplex)
             subtriangulation = self._subtriangulations[simplex]
             for subsimplex in subtriangulation.simplices:
                 subloss = subtriangulation.volume(subsimplex) * loss_density
-                self._losses_combined_list.add((subloss, simplex, subsimplex))
-                self._sub_losses[(simplex, subsimplex)] = subloss
+                heapq.heappush(self._losses_combined, 
+                               (-subloss, simplex, subsimplex))
 
     def losses(self):
         """Get the losses of each simplex in the current triangulation, as dict

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -411,15 +411,18 @@ class Triangulation:
 
             if self.point_in_cicumcircle(pt_index, simplex, transform):
                 self.delete_simplex(simplex)
-                todo_points = set(simplex) - done_points
+                todo_points = set(simplex)
                 done_points.update(simplex)
 
-                if len(todo_points):
-                    neighbours = set.union(*[self.vertex_to_simplices[p]
-                                             for p in todo_points])
-                    queue.update(neighbours - done_simplices)
-
                 bad_triangles.add(simplex)
+                if len(todo_points) == 0:
+                    continue
+                neighbours = set.union(*[self.vertex_to_simplices[p]
+                                            for p in todo_points])
+                neighbours = neighbours - done_simplices
+                neighbours = set(simpl for simpl in neighbours if len(set(simpl) & done_points) >= self.dim)
+                queue.update(neighbours)
+
 
         faces = list(self.faces(simplices=bad_triangles))
 

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -520,6 +520,10 @@ class Triangulation:
         deleted_simplices = bad_triangles - new_triangles
         new_simplices = new_triangles - bad_triangles
 
+        old_vol = sum([self.volume(simplex) for simplex in deleted_simplices])
+        new_vol = sum([self.volume(simplex) for simplex in new_simplices])
+        assert np.isclose(old_vol, new_vol), f"{old_vol} !== {new_vol}"
+
         return deleted_simplices, new_simplices
 
     def add_point(self, point, simplex=None, transform=None):

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -202,8 +202,16 @@ def simplex_volume_in_embedding(vertices) -> float:
     # Implements http://mathworld.wolfram.com/Cayley-MengerDeterminant.html
     # Modified from https://codereview.stackexchange.com/questions/77593/calculating-the-volume-of-a-tetrahedron
 
-    # β_ij = |v_i - v_k|²
+    
     vertices = np.array(vertices, dtype=float)
+    dim = len(vertices[0])
+    if dim == 2:
+        # Heron's formula
+        a, b, c = scipy.spatial.distance.pdist(vertices, metric='euclidean')
+        s = 0.5 * (a + b + c)
+        return math.sqrt(s*(s-a)*(s-b)*(s-c))
+
+    # β_ij = |v_i - v_k|²
     sq_dists = scipy.spatial.distance.pdist(vertices, metric='sqeuclidean')
 
     # Add border while compressed

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -504,14 +504,6 @@ class Triangulation:
         deleted_simplices = bad_triangles - new_triangles
         new_simplices = new_triangles - bad_triangles
 
-        if not np.isclose(sum([self.volume(s) for s in deleted_simplices]),
-                          sum([self.volume(s) for s in new_simplices])):
-            print("vertices = ", self.vertices, "\n\n\n")
-            print("simplices = ", self.simplices, "\n\n\n")
-            print("new_s = ", new_simplices)
-            print("old_s = ", deleted_simplices)
-            print("holes_faces = ", hole_faces)
-            raise AssertionError("debug me")
         return deleted_simplices, new_simplices
 
     def add_point(self, point, simplex=None, transform=None):

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -29,6 +29,17 @@ def fast_2d_point_in_simplex(point, simplex, eps=1e-8):
     return (t >= -eps) and (s + t <= 1 + eps)
 
 
+def point_in_simplex(point, simplex, eps=1e-8):
+    if len(point) == 2:
+        return fast_2d_point_in_simplex(point, simplex, eps)
+
+    x0 = np.array(simplex[0], dtype=float)
+    vectors = np.array(simplex[1:], dtype=float) - x0
+    alpha = np.linalg.solve(vectors.T, point - x0)
+
+    return all(alpha > -eps) and sum(alpha) < 1 + eps
+
+
 def fast_2d_circumcircle(points):
     """Compute the center and radius of the circumscribed circle of a triangle
 
@@ -102,6 +113,32 @@ def fast_3d_circumcircle(points):
     center = [dx / a, -dy / a, dz / a]
     radius = fast_norm(center)
     center = np.add(center, points[0])
+
+    return tuple(center), radius
+
+
+def circumsphere(pts):
+    dim = len(pts) - 1
+    if dim == 2:
+        return fast_2d_circumcircle(pts)
+    if dim == 3:
+        return fast_3d_circumcircle(pts)
+
+    # Modified method from http://mathworld.wolfram.com/Circumsphere.html
+    mat = [[np.sum(np.square(pt)), *pt, 1] for pt in pts]
+
+    center = []
+    for i in range(1, len(pts)):
+        r = np.delete(mat, i, 1)
+        factor = (-1) ** (i + 1)
+        center.append(factor * np.linalg.det(r))
+
+    a = np.linalg.det(np.delete(mat, 0, 1))
+    center = [x / (2 * a) for x in center]
+
+    x0 = pts[0]
+    vec = np.subtract(center, x0)
+    radius = fast_norm(vec)
 
     return tuple(center), radius
 
@@ -227,15 +264,8 @@ class Triangulation:
         return [simplex[i] for i in result]
 
     def point_in_simplex(self, point, simplex, eps=1e-8):
-        if self.dim == 2:
-            vertices = self.get_vertices(simplex)
-            return fast_2d_point_in_simplex(point, vertices, eps)
-        elif self.dim == 3:
-            # XXX: Better to write a separate function for this
-            return len(self.get_reduced_simplex(point, simplex, eps)) > 0
-        else:
-            # XXX: Better to write a separate function for this
-            return len(self.get_reduced_simplex(point, simplex, eps)) > 0
+        vertices = self.get_vertices(simplex)
+        return point_in_simplex(point, vertices, eps)
 
     def locate_point(self, point):
         """Find to which simplex the point belongs.
@@ -330,28 +360,7 @@ class Triangulation:
             The center and radius of the circumscribed circle
         """
         pts = np.dot(self.get_vertices(simplex), transform)
-        if self.dim == 2:
-            return fast_2d_circumcircle(pts)
-        if self.dim == 3:
-            return fast_3d_circumcircle(pts)
-
-        # Modified method from http://mathworld.wolfram.com/Circumsphere.html
-        mat = [[np.sum(np.square(pt)), *pt, 1] for pt in pts]
-
-        center = []
-        for i in range(1, len(simplex)):
-            r = np.delete(mat, i, 1)
-            factor = (-1) ** (i+1)
-            center.append(factor * np.linalg.det(r))
-
-        a = np.linalg.det(np.delete(mat, 0, 1))
-        center = [x / (2*a) for x in center]
-
-        x0 = self.vertices[next(iter(simplex))]
-        vec = np.subtract(center, x0)
-        radius = fast_norm(vec)
-
-        return tuple(center), radius
+        return circumsphere(pts)
 
     def point_in_cicumcircle(self, pt_index, simplex, transform):
         # return self.fast_point_in_circumcircle(pt_index, simplex, transform)

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -9,6 +9,8 @@ def fast_norm(v):
     # notice this method can be even more optimised
     if len(v) == 2:
         return math.sqrt(v[0] * v[0] + v[1] * v[1])
+    if len(v) == 3:
+        return math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
     return math.sqrt(np.dot(v, v))
 
 
@@ -81,8 +83,11 @@ def fast_3d_circumcircle(points):
     points = np.array(points)
     pts = points[1:] - points[0]
 
-    l1, l2, l3 = [np.dot(p, p) for p in pts]  # length squared
     (x1, y1, z1), (x2, y2, z2), (x3, y3, z3) = pts
+
+    l1 = x1 * x1 + y1 * y1 + z1 * z1
+    l2 = x2 * x2 + y2 * y2 + z2 * z2
+    l3 = x3 * x3 + y3 * y3 + z3 * z3
 
     # Compute some determinants:
     dx = (+ l1 * (y2 * z3 - z2 * y3)
@@ -99,11 +104,13 @@ def fast_3d_circumcircle(points):
           + x3 * (y1 * z2 - z1 * y2))
     a = 2 * aa
 
-    center = [dx / a, -dy / a, dz / a]
+    center = (dx / a, -dy / a, dz / a)
     radius = fast_norm(center)
-    center = np.add(center, points[0])
+    center = (center[0] + points[0][0],
+              center[1] + points[0][1],
+              center[2] + points[0][2])
 
-    return tuple(center), radius
+    return center, radius
 
 
 def orientation(face, origin):

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, Counter, Sized, Iterable
+from collections import Counter, Sized, Iterable
 from itertools import combinations, chain
 
 import numpy as np

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -487,7 +487,7 @@ class Triangulation:
         prefactor = np.math.factorial(self.dim)
         vertices = np.array(self.get_vertices(simplex))
         vectors = vertices[1:] - vertices[0]
-        return abs(np.linalg.det(vectors)) / prefactor
+        return float(abs(np.linalg.det(vectors)) / prefactor)
 
     def volumes(self):
         return [self.volume(sim) for sim in self.simplices]

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -217,7 +217,7 @@ def simplex_volume_in_embedding(vertices) -> float:
     vol_square = np.linalg.det(sq_dists_mat) / coeff
 
     if vol_square <= 0:
-        raise ValueError('Provided vertices do not form a tetrahedron')
+        raise ValueError('Provided vertices do not form a simplex')
 
     return np.sqrt(vol_square)
 

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -3,6 +3,8 @@ from itertools import combinations, chain
 
 import numpy as np
 import math
+import scipy.spatial
+from math import factorial
 
 
 def fast_norm(v):
@@ -171,6 +173,53 @@ def orientation(face, origin):
 
 def is_iterable_and_sized(obj):
     return isinstance(obj, Iterable) and isinstance(obj, Sized)
+
+
+def simplex_volume_in_embedding(vertices) -> float:
+    """Calculate the volume of a simplex in a higher dimensional embedding.
+    That is: dim > len(vertices) - 1. For example if you would like to know the 
+    surface area of a triangle in a 3d space.
+
+    Parameters
+    ----------
+    vertices: arraylike (2 dimensional)
+        array of points
+
+    Returns
+    -------
+    volume: int
+        the volume of the simplex with given vertices.
+
+    Raises
+    ------
+    ValueError:
+        if the vertices do not form a simplex (for example,
+        because they are coplanar, colinear or coincident).
+
+    Warning: this algorithm has not been tested for numerical stability.
+    """
+
+    # Implements http://mathworld.wolfram.com/Cayley-MengerDeterminant.html
+    # Modified from https://codereview.stackexchange.com/questions/77593/calculating-the-volume-of-a-tetrahedron
+
+    # β_ij = |v_i - v_k|²
+    vertices = np.array(vertices, dtype=float)
+    sq_dists = scipy.spatial.distance.pdist(vertices, metric='sqeuclidean')
+
+    # Add border while compressed
+    num_verts = scipy.spatial.distance.num_obs_y(sq_dists)
+    bordered = np.concatenate((np.ones(num_verts), sq_dists))
+
+    # Make matrix and find volume
+    sq_dists_mat = scipy.spatial.distance.squareform(bordered)
+
+    coeff = - (-2) ** (num_verts-1) * factorial(num_verts-1) ** 2
+    vol_square = np.linalg.det(sq_dists_mat) / coeff
+
+    if vol_square <= 0:
+        raise ValueError('Provided vertices do not form a tetrahedron')
+
+    return np.sqrt(vol_square)
 
 
 class Triangulation:

--- a/adaptive/tests/test_learnernd.py
+++ b/adaptive/tests/test_learnernd.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
 
 from ..learner import LearnerND
-from ..runner import replay_log
+from ..runner import replay_log, BlockingRunner
+import numpy as np
 
 
-def test_faiure_case_LearnerND():
+def sphere(xyz):
+    x, y, z = xyz
+    a = 0.4
+    return x + z**2 + np.exp(-(x**2 + y**2 + z**2 - 0.75**2)**2/a**4)
+
+
+def test_failure_case_LearnerND():
     log = [
         ('ask', 4),
         ('tell', (-1, -1, -1), 1.607873907219222e-101),
@@ -21,3 +28,18 @@ def test_faiure_case_LearnerND():
     ]
     learner = LearnerND(lambda *x: x, bounds=[(-1, 1), (-1, 1), (-1, 1)])
     replay_log(learner, log)
+
+
+def test_anisotropic_3d():
+    # there was this bug that the total volume would exceed the bounding box 
+    # volume for the anisotropic 3d learnerND
+    # learner = adaptive.LearnerND(ring, bounds=[(-1, 1), (-1, 1)], anisotropic=True)
+    learner = LearnerND(sphere, bounds=[(-1, 1), (-1, 1), (-1, 1)], anisotropic=True)
+    def goal(l):
+        if l.tri:
+            sum_of_simplex_volumes = np.sum(l.tri.volumes())
+            assert sum_of_simplex_volumes < 8.00000000001
+        return l.npoints >= 1000
+    BlockingRunner(learner, goal, ntasks=1)
+
+    assert learner.npoints >= 1000


### PR DESCRIPTION
## ([original merge request on GitLab](https://gitlab.kwant-project.org/qt/adaptive/merge_requests/90))

_opened by Jorn Hoofwijk ([@Jorn](https://gitlab.kwant-project.org/Jorn)) at 2018-07-25T11:37:55.550Z_

Closes [gitlab:#74](https://gitlab.kwant-project.org/qt/adaptive/issues/74) 

Depends on [gitlab:!86](https://gitlab.kwant-project.org/qt/adaptive/merge_requests/86) and [gitlab:#80](https://gitlab.kwant-project.org/qt/adaptive/issues/80) and therefore it has the corresponding branches included as well


Still has a few to-do's:
- [x] let `LearnerND.ip()` make use of our triangulation rather than building a new one
- [ ] make it work in arbitrary dimensions
- [ ] verify that it is beneficial
- ~~let the user configure the parameters (maximum stretch factor and number of points to take into account)~~ Use one simplex and it's neighbours
- [x] make test pass
    - ~~add `rtree` as install requirement~~ No more RTree anymore :)
    - ~~raise exception if `anistropic=True` and `rtree` not installed, pass if `anisotropic=False`~~
- [x] refactor code to be human-readable
- ~~let's make it fast :)~~ [gitlab:#80](https://gitlab.kwant-project.org/qt/adaptive/issues/80)

As it seems it doesn't work that well with the ring, since this ring has a relative low average gradient and very high second derivative. So maybe this second derivative might be a more useful property to determine the 

Sneak peek:
![anisotropic](/uploads/3babecfe20b8ac4d6edff89566707e9e/anisotropic.png)